### PR TITLE
using repo instead of remote file

### DIFF
--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -192,7 +192,7 @@ function  qs_enable_epel() {
     if [ "$INSTANCE_OSTYPE" == "rhel" ]; then
         yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     elif [ "$INSTANCE_OSTYPE" == "centos" ]; then
-        yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+        yum install -y epel-release
     elif [ "$INSTANCE_OSTYPE" == "fedora" ]; then
         echo "Enabled!"
     else


### PR DESCRIPTION
By using the repo version of epel-release the function qs_enable_epel becomes idempotent. The operation shouldn't fail when epel is installed.