### PR TITLE
Accounting for distros on sysvinit.

### DIFF
--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -1,6 +1,6 @@
 #!/usr/bin/bash -e
 # QuickStart Common Linux Tools
-# author: tonynv@amazon.com
+# authors: tonynv@amazon.com, andglenn@amazon.com
 #
 
 # Supported only while bootstrapping Amazon ec2:
@@ -35,6 +35,36 @@ PROGRAM='QuickStart Linux Common Tools'
 # Detects operating system type and return value
 # If no variable is passed in function will print to std-out
 #
+
+function qs_int_set_svc_executable(){
+    if [[ $(which systemctl) ]]; then
+        export qs_svc_executable="systemd"
+    else
+        export qs_svc_executable="sysvinit"
+    fi
+}
+
+function qs_int_is_svc_active(){
+    case ${qs_svc_executable} in
+        systemd)
+            systemctl is-active --quiet ${1}.service
+            ;;
+        sysvinit)
+            service ${1} status
+            ;;
+    esac
+}
+
+function qs_int_service_restart() {
+    case ${qs_svc_executable} in
+        systemd)
+            systemctl restart ${1}.service
+            ;;
+        sysvinit)
+            service ${1} restart
+            ;;
+    esac
+}
 
 function qs_get-ostype() {
     local __return=$1
@@ -163,7 +193,7 @@ function  qs_bootstrap_pip() {
 function  qs_cloudwatch_tracklog() {
     local -r __log="$@"
     cat cloudwatch_logs.stub | sed s,__LOG__,$__log,g >> /var/awslogs/etc/awslogs.conf
-    systemctl restart awslogs.service
+    qs_int_service_restart awslogs
 }
 
 function  qs_cloudwatch_install() {
@@ -179,7 +209,7 @@ function  qs_cloudwatch_install() {
     https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py -O
     sudo $PYTHON_EXECUTEABLE ./awslogs-agent-setup.py --region $REGION -c awslogs.conf -n
     else
-      systemctl is-active --quiet awslogs.service && echo "[INFO] Cloudwatch Service is running"
+      qs_int_is_svc_active awslogs && echo "[INFO] Cloudwatch Service is running"
         exit 1
     fi
 }


### PR DESCRIPTION
Fixes #9. 

Basic testing.

```
[root@ip-10-0-152-185 qs-linux-utils]# source quickstart-cfn-tools.source                                                                                          [20/1717]
--------------------------------
Available quickstart_functions:
    #qs_err
    #qs_status
    #qs_get-ostype
    #qs_get-osversion
    #qs_get-python-path
    #qs_bootstrap_pip
    #qs_update-os
    #qs_enable_epel
    #qs_notty
    #qs_aws-cfn-bootstrap
    #qs_cloudwatch_tracklog
    #qs_cloudwatch_install
    #qs_retry_command
--------------------------------
[INFO] Dependencies Met!
[root@ip-10-0-152-185 qs-linux-utils]# less /var/log/cfn-init-cmd.log 
[root@ip-10-0-152-185 qs-linux-utils]# qs_cloudwatch_install 
[INFO] Install AWS CloudWatch Agent
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   467  100   467    0     0   106k      0 --:--:-- --:--:-- --:--:--  114k

Step 1 of 5: Installing pip ...DONE

Step 2 of 5: Downloading the latest CloudWatch Logs agent bits ... DONE


Step 5 of 5: Setting up agent as a daemon ...DONE


------------------------------------------------------
- Configuration file successfully saved at: /var/awslogs/etc/awslogs.conf
- You can begin accessing new log events after a few moments at https://console.aws.amazon.com/cloudwatch/home?region=us-east-2#logs:
- You can use 'sudo service awslogs start|stop|status|restart' to control the daemon.
- To see diagnostic information for the CloudWatch Logs Agent, see /var/log/awslogs.log
- You can rerun interactive setup using 'sudo python ./awslogs-agent-setup.py --region us-east-2 --only-generate-config'
------------------------------------------------------
[root@ip-10-0-152-185 qs-linux-utils]# qs_cloudwatch_tracklog /var/log/messages 
[root@ip-10-0-152-185 qs-linux-utils]# less /var/l^C
[root@ip-10-0-152-185 qs-linux-utils]# less ^C
[root@ip-10-0-152-185 qs-linux-utils]# cat /var/awslogs/etc/awslogs.conf 
[general]
```