### PR TITLE
Add support Amazon Linux2 (Update Ubuntu)

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -24,8 +24,6 @@ tests:
       GitRepo: https://github.com/username/quickstart-linux-utilities.git
       TestAMIOS: Amazon-Linux2-HVM
     template: templates/ci_test-master.template.yaml
-    regions:
-    - us-east-1
   Amazon-Linux1:
     parameters:
       AccessCIDR: 0.0.0.0/0
@@ -34,8 +32,6 @@ tests:
       GitRepo: https://github.com/username/quickstart-linux-utilities.git
       TestAMIOS: Amazon-Linux-HVM
     template: templates/ci_test-master.template.yaml
-    regions:
-    - us-east-2
   Ubuntu1604:
     parameters:
       AccessCIDR: 0.0.0.0/0
@@ -44,5 +40,3 @@ tests:
       GitRepo: https://github.com/username/quickstart-linux-utilities.git
       TestAMIOS: Ubuntu-Server-16.04-LTS-HVM
     template: templates/ci_test-master.template.yaml
-    regions:
-    - us-east-1

--- a/ci/amzn.json
+++ b/ci/amzn.json
@@ -1,0 +1,7 @@
+{
+   "AccessCIDR": "0.0.0.0/0",
+   "AvailabilityZones": "$[taskcat_getaz_2]",
+   "BucketName": "$[taskcat_autobucket]",
+   "GitRepo": "https://github.com/username/quickstart-linux-utilities.git",
+   "TestAMIOS": "Amazon-Linux2-HVM"
+}

--- a/ci/taskcat.yml
+++ b/ci/taskcat.yml
@@ -1,0 +1,21 @@
+global:
+  owner: tonynv@amazon.com
+  qsname: quickstart-linux-utilities
+  regions:
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - ca-central-1
+    - eu-central-1
+    - eu-west-2
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+  reporting: true
+tests:
+  linux-amzn:
+    parameter_input: amzn.json
+    template_file: ci_test-master.template.yaml 


### PR DESCRIPTION
*Issue #, if available:*

Fixes: https://github.com/aws-quickstart/quickstart-linux-utilities/issues/11

*Description of changes:*

Adds support for **Amazon Linux 2**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
