### PR TITLE
Updated location of get-pip.py

### DIFF
--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -176,7 +176,7 @@ function  qs_bootstrap_pip() {
             curl --silent \
              --show-error \
             --retry 5 \
-            https://bootstrap.pypa.io/get-pip.py | sudo $PYTHON_EXECUTEABLE
+            https://bootstrap.pypa.io/2.7/get-pip.py | sudo $PYTHON_EXECUTEABLE
         fi
     else
         echo $PYTHON_EXECUTEABLE
@@ -292,7 +292,7 @@ function qs_aws-cfn-bootstrap() {
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ] && [ "$INSTANCE_OSVERSION" == "20.04" ]; then
         sudo apt-get update -y
         apt-get install python2.7 -y
-        curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
+        curl https://bootstrap.pypa.io/2.7/get-pip.py --output get-pip.py
         sudo python2.7 get-pip.py
         sudo pip2 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "rhel" ]; then


### PR DESCRIPTION
*Issue #, if available:* Several quick starts are failing with the following error:

```
+ curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py
+ sudo /bin/python
Traceback (most recent call last):
  File "<stdin>", line 24226, in <module>
  File "<stdin>", line 199, in main
  File "<stdin>", line 82, in bootstrap
  File "/tmp/tmpY53gxb/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
+ pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
quickstart-cfn-tools.source: line 304: pip: command not found
```

*Description of changes:* 
Updated location of git-pip.py.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
