### PR TITLE
Incomplete package update command for Ubuntu in function qs_update-os()

### DIFF
--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -244,7 +244,7 @@ function qs_update-os() {
     if [ "$INSTANCE_OSTYPE" == "amzn" ]; then
         yum update -y
     elif [ "$INSTANCE_OSTYPE" == "ubuntu" ]; then
-        apt update -y
+        apt update && apt upgrade -y
     elif [ "$INSTANCE_OSTYPE" == "rhel" ]; then
         yum update -y
     elif [ "$INSTANCE_OSTYPE" == "centos" ]; then


### PR DESCRIPTION
OS Update command in the function qs_update-os() for Ubuntu is only partially implemented (apt update). The actual package upgrade command (apt upgrade) is missed out. Completed the upgrade command for ubuntu

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
