### PR TITLE
Bump CloudFormation helper scripts for SLES

### DIFF
--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -306,9 +306,7 @@ function qs_aws-cfn-bootstrap() {
         pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
     elif [ "$INSTANCE_OSTYPE" == "sles" ]; then
         zypper -n refresh && zypper -n update
-        zypper -n install python2-pip
-        pip2.7 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-        echo "[WARNING] not implemeneted"
+        pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz
     else
         exit 1
     fi

--- a/quickstart-cfn-tools.source
+++ b/quickstart-cfn-tools.source
@@ -5,8 +5,8 @@
 
 # Supported only while bootstrapping Amazon ec2:
 #
-# -Amazon Linux2        
-# -Red Hat Enterprise Linux 7   
+# -Amazon Linux2
+# -Red Hat Enterprise Linux 7
 # -Ubuntu 20.04
 #
 #
@@ -402,7 +402,6 @@ else
     echo "[FAIL] : Dependencies not satisfied!"
     exit 1
 fi
-
 }
 
 # $1 = NumberOfRetries $2 = Command
@@ -424,11 +423,9 @@ function qs_retry_command() {
                         sleep $((((__backoff_delay++)) + ((__current_try++))))
                 fi
         done
-
 }
 
 # start exec
 available_functions
 install_dependancies
 # end exec
-


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/aws-quickstart/quickstart-linux-bastion/pull/142
* https://github.com/aws-quickstart/quickstart-linux-bastion/pull/156

*Description of changes:* SLES 15.4 no longer supports the python2-pip package, so corresponding Linux bastion builds are failing on this step before installing the CloudFormation helper scripts, which means they fail to signal failure. 

Walked through a build manually with these changes successfully. 

Also, did not implement for other distros yet as ran into a few syntax warnings in the [cfn-init 2.0-12 release](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/releasehistory-aws-cfn-bootstrap.html) when testing Ubuntu 20.04 afterward.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
